### PR TITLE
smart_merge: do not assign `log` in case of GitCommandError

### DIFF
--- a/legit/scm.py
+++ b/legit/scm.py
@@ -138,7 +138,7 @@ def smart_merge(branch, allow_rebase=True):
     try:
         return repo.git.execute([git, verb, branch])
     except GitCommandError, why:
-        log = repo.git.execute([git,'merge', '--abort'])
+        repo.git.execute([git,'merge', '--abort'])
         abort('Merge failed. Reverting.', log=why)
 
 


### PR DESCRIPTION
In case of error `why` is used for the `log` argument to `abort`.
It might get changed to also pass on the output from `git merge --abort`
via `log` or something similar though?!