### PR TITLE
abort the correct verb when smart_merge fails

### DIFF
--- a/legit/scm.py
+++ b/legit/scm.py
@@ -14,7 +14,7 @@ from collections import namedtuple
 from operator import attrgetter
 
 from git import Repo
-from git.exc import GitCommandError
+from git.exc import GitCommandError,  InvalidGitRepositoryError
 
 from .settings import settings
 
@@ -211,7 +211,7 @@ def get_repo():
 
     try:
         return Repo()
-    except git.exc.InvalidGitRepositoryError:
+    except InvalidGitRepositoryError:
         pass
 
 

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -137,8 +137,8 @@ def smart_merge(branch, allow_rebase=True):
     try:
         return repo.git.execute([git, verb, branch])
     except GitCommandError as why:
-        log = repo.git.execute([git,'merge', '--abort'])
-        abort('Merge failed. Reverting.', log=why)
+        log = repo.git.execute([git, verb, '--abort'])
+        abort('Merge failed. Reverting.', log='{0}\n{1}'.format(why, log))
 
 
 


### PR DESCRIPTION
in case of error, `git merge --abort` is hardcoded but sometimes you have to do `git rebase --abort`

\+ log format copied from `graft_branch`