### PR TITLE
Stop get_remote if not in git repository

### DIFF
--- a/legit/scm.py
+++ b/legit/scm.py
@@ -280,4 +280,5 @@ def get_branch_names(local=True, remote_branches=True):
 
 
 repo = get_repo()
-remote = get_remote()
+if repo:  # in git repository
+    remote = get_remote()


### PR DESCRIPTION
`remote` variable is not used when in not git repo.
and this is to fix::

* `legit install` in directory which does not have `.git`.

```
$ # in not git repo
$ legit install
Not a git repository.

$ # in git repo without .git
$ legit install
Not a git repository.

$ # in dir with .git
$ legit install
The following git aliases have been installed:

  git                  !legit branches
  branches
  git graft            !legit graft
  git                  !legit harvest
  harvest
  git                  !legit publish
  publish
  git                  !legit unpublish
  unpublish
  git                  !legit sprout
  sprout
  git sync             !legit sync
  git                  !legit switch
  switch
  git                  !legit resync
  resync
```