### PR TITLE
Update documentation for resync command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,13 @@ The Interface
     Stash, Fetch, Auto-Merge/Rebase, Push, and Unstash.
     You can only sync published branches.
 
+``resync <upstream-branch>``
+    Stashes unstaged changes,
+    Fetches, Auto-Merge/Rebase upstream data from specified upstream branch,
+    Performs smart pull+merge for current branch,
+    Pushes local commits up, and Unstashes changes.
+    Default upstream branch is 'master'.
+
 ``switch <branch>``
     Switches to specified branch.
     Defaults to current branch.

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ The Interface
     Get a nice pretty list of available branches.
 
 ``sync [<branch>]``
-    Syncronizes the given branch. Defaults to current branch.
+    Synchronizes the given branch. Defaults to current branch.
     Stash, Fetch, Auto-Merge/Rebase, Push, and Unstash.
     You can only sync published branches.
 

--- a/legit/cli.py
+++ b/legit/cli.py
@@ -145,13 +145,13 @@ def cmd_switch(args):
     if unstash_index(branch=from_branch):
         status_log(unstash_it, 'Restoring local changes.', branch=from_branch)
 
+
 def cmd_resync(args):
-    """Stashes unstaged changes, 
-    Fetches upstream data from master branch,
-    Auto-Merge/Rebase from master branch 
-    Performs smart pull+merge, 
+    """Stashes unstaged changes,
+    Fetches, Auto-Merge/Rebase upstream data from specified upstream branch,
+    Performs smart pull+merge for current branch,
     Pushes local commits up, and Unstashes changes.
-    Defaults to current branch.
+    Default upstream branch is 'master'.
     """
     if args.get(0):
         upstream = fuzzy_match_branch(args.get(0))
@@ -167,15 +167,19 @@ def cmd_resync(args):
     original_branch = repo.head.ref.name
     if repo.is_dirty():
         status_log(stash_it, 'Saving local changes.', sync=True)
+    # Update upstream branch
     switch_to(upstream)
     status_log(smart_pull, 'Pulling commits from the server.')
+    # Update original branch with upstream
     switch_to(original_branch)
     status_log(smart_merge, 'Grafting commits from {0}.'.format(
         colored.yellow(upstream)), upstream, allow_rebase=False)
     if unstash_index(sync=True):
         status_log(unstash_it, 'Restoring local changes.', sync=True)
+    # Sync original_branch
     status_log(smart_pull, 'Pulling commits from the server.')
     status_log(push, 'Pushing commits to the server.', original_branch)
+
 
 def cmd_sync(args):
     """Stashes unstaged changes, Fetches remote data, Performs smart
@@ -664,13 +668,16 @@ def_cmd(
     usage='sync <branch>',
     help=('Syncronizes the given branch. Defaults to current branch. Stash, '
           'Fetch, Auto-Merge/Rebase, Push, and Unstash.'))
+
 def_cmd(
     name='resync',
     short=['rs'],
     fn=cmd_resync,
-    usage='sync <branch>',
-    help=('Syncronizes the given branch. Defaults to current branch. Stash, '
-          'Fetch, Auto-Merge/Rebase, Push, and Unstash.'))
+    usage='resync <upstream-branch>',
+    help=('Re-synchronize current branch with specified upstream branch. '
+          "Defaults upstream branch is 'master'. "
+          'Fetch, Auto-Merge/Rebase for upstream, '
+          'Fetch, Auto-Merge/Rebase, Push, and Unstash for current branch.'))
 
 def_cmd(
     name='unpublish',

--- a/legit/cli.py
+++ b/legit/cli.py
@@ -666,7 +666,7 @@ def_cmd(
     short=['sy'],
     fn=cmd_sync,
     usage='sync <branch>',
-    help=('Syncronizes the given branch. Defaults to current branch. Stash, '
+    help=('Synchronizes the given branch. Defaults to current branch. Stash, '
           'Fetch, Auto-Merge/Rebase, Push, and Unstash.'))
 
 def_cmd(


### PR DESCRIPTION
Maybe `resync` can be improved to receive optional argument:

```
$ legit resync [<branch>] <upstream-branch>
```

to resync **branch** with **upstream-branch** .

(Current behavior is resync current_branch with upstream-branch)