### PR TITLE
Support special expression for branch

### DIFF
--- a/legit/cli.py
+++ b/legit/cli.py
@@ -118,7 +118,7 @@ def fuzzy_match_branch(branch):
     if len(possible_branches) == 1:
         return possible_branches[0]
 
-    return False
+    return branch
 
 # --------
 # Commands
@@ -130,11 +130,6 @@ def cmd_switch(args):
     from_branch = get_current_branch_name()
     to_branch = args.get(0)
     to_branch = fuzzy_match_branch(to_branch)
-
-    if not to_branch:
-        print('Please specify a branch to switch to:')
-        display_available_branches()
-        sys.exit()
 
     if repo.is_dirty():
         status_log(stash_it, 'Saving local changes.')

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -158,7 +158,9 @@ def checkout_branch(branch):
 
     repo_check()
 
-    return repo.git.execute([git, 'checkout', branch])
+    _, stdout, stderr = repo.git.execute([git, 'checkout', branch],
+                                         with_extended_output=True)
+    return '\n'.join([stderr, stdout])
 
 
 def sprout_branch(off_branch, branch):


### PR DESCRIPTION
Closes #46 

```sh
% legit switch master
Switching to master.
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
% legit switch -
Switching to -.
Switched to branch 'develop'
Your branch is up-to-date with 'master'.
```