### PR TITLE
Install completion & man file via pip as data_files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,12 @@ settings.update(
         'console_scripts': [
             'legit = legit.cli:main',
         ],
-    }
+    },
+    data_files=[
+        ('man/man1', ['extra/man/legit.1']),
+        ('etc/bash_completion.d', ['extra/bash-completion/legit']),
+        ('share/zsh/site-functions', ['extra/zsh-completion/_legit']),
+    ],
 )
 
 


### PR DESCRIPTION
This can be controversial because the location can be not standard one depending on sys.prefix.
If using Homebrew's python on MacOSX, it does work (installed under `/usr/local`)
 but does not if using system python (installed under `/System/Library/Frameworks/Python.framework/Versios/2.7`)
In Linux, it is installed under `/usr/local`, so it should work.
