### PR TITLE
partially revert #111, to fix bug with previous intented behavior

### DIFF
--- a/legit/cli.py
+++ b/legit/cli.py
@@ -128,7 +128,6 @@ def fuzzy_match_branch(branch):
 def cmd_switch(args):
     """Legit Switch command."""
 
-    from_branch = get_current_branch_name()
     to_branch = args.get(0)
     to_branch = fuzzy_match_branch(to_branch)
 
@@ -138,8 +137,8 @@ def cmd_switch(args):
     status_log(checkout_branch, 'Switching to {0}.'.format(
         colored.yellow(to_branch)), to_branch)
 
-    if unstash_index(branch=from_branch):
-        status_log(unstash_it, 'Restoring local changes.', branch=from_branch)
+    if unstash_index():
+        status_log(unstash_it, 'Restoring local changes.')
 
 
 def cmd_resync(args):


### PR DESCRIPTION
In #111 the behavior of the switch command changed and broke the previous intented behavior. This pr partially reverts the changes and restores back the old behavior of the switch command.

If we want to also support the new way of switching introduced in #111 I think we should create a new command. Something like `git port <to_branch>`. This would mean stashing current changes, switching `to_branch` and unstashing the previous changes

Fixes #196