### PR TITLE
Works with repos without remotes.

### DIFF
--- a/legit/cli.py
+++ b/legit/cli.py
@@ -183,6 +183,8 @@ def cmd_sync(args):
     Defaults to current branch.
     """
 
+    repo_check(require_remote=True)
+
     if args.get(0):
         # Optional branch specifier.
         branch = fuzzy_match_branch(args.get(0))
@@ -306,6 +308,7 @@ def cmd_graft(args):
 def cmd_publish(args):
     """Pushes an unpublished branch to a remote repository."""
 
+    repo_check(require_remote=True)
     branch = fuzzy_match_branch(args.get(0))
 
     if not branch:
@@ -331,6 +334,7 @@ def cmd_publish(args):
 def cmd_unpublish(args):
     """Removes a published branch from the remote repository."""
 
+    repo_check(require_remote=True)
     branch = fuzzy_match_branch(args.get(0))
 
     if not branch:

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -111,7 +111,7 @@ def fetch():
 def smart_pull():
     'git log --merges origin/master..master'
 
-    repo_check()
+    repo_check(require_remote=True)
 
     branch = get_current_branch_name()
 
@@ -145,7 +145,7 @@ def smart_merge(branch, allow_rebase=True):
 
 def push(branch=None):
 
-    repo_check()
+    repo_check(require_remote=True)
 
     if branch is None:
         return repo.git.execute([git, 'push'])
@@ -195,7 +195,7 @@ def graft_branch(branch):
 def unpublish_branch(branch):
     """Unpublishes given branch."""
 
-    repo_check()
+    repo_check(require_remote=True)
 
     try:
         return repo.git.execute([git,
@@ -209,7 +209,7 @@ def unpublish_branch(branch):
 def publish_branch(branch):
     """Publishes given branch."""
 
-    repo_check()
+    repo_check(require_remote=True)
 
     return repo.git.execute([git,
         'push', '-u', remote.name, branch])
@@ -230,19 +230,16 @@ def get_remote():
 
     reader = repo.config_reader()
 
-    if repo.remotes:
-        # If there is no remote option in legit section, return default
-        if not reader.has_option('legit', 'remote'):
-            return repo.remotes[0]
+    # If there is no remote option in legit section, return default
+    if not reader.has_option('legit', 'remote'):
+        return repo.remotes[0]
 
-        remote_name = reader.get('legit', 'remote')
-        if not remote_name in [r.name for r in repo.remotes]:
-            raise ValueError('Remote "{0}" does not exist! Please update your git '
+    remote_name = reader.get('legit', 'remote')
+    if not remote_name in [r.name for r in repo.remotes]:
+        raise ValueError('Remote "{0}" does not exist! Please update your git '
                              'configuration.'.format(remote_name))
 
-        return repo.remote(remote_name)
-    else:
-        return None
+    return repo.remote(remote_name)
 
 
 def get_current_branch_name():

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -226,20 +226,23 @@ def get_repo():
 
 def get_remote():
 
-    repo_check(require_remote=True)
+    repo_check()
 
     reader = repo.config_reader()
 
-    # If there is no remote option in legit section, return default
-    if not reader.has_option('legit', 'remote'):
-        return repo.remotes[0]
+    if repo.remotes:
+        # If there is no remote option in legit section, return default
+        if not reader.has_option('legit', 'remote'):
+            return repo.remotes[0]
 
-    remote_name = reader.get('legit', 'remote')
-    if not remote_name in [r.name for r in repo.remotes]:
-        raise ValueError('Remote "{0}" does not exist! Please update your git '
-                         'configuration.'.format(remote_name))
+        remote_name = reader.get('legit', 'remote')
+        if not remote_name in [r.name for r in repo.remotes]:
+            raise ValueError('Remote "{0}" does not exist! Please update your git '
+                             'configuration.'.format(remote_name))
 
-    return repo.remote(remote_name)
+        return repo.remote(remote_name)
+    else:
+        return None
 
 
 def get_current_branch_name():
@@ -255,7 +258,9 @@ def get_branches(local=True, remote_branches=True):
 
     repo_check()
 
-    # print local
+    if not repo.remotes:
+        remote_branches = False
+
     branches = []
 
     if remote_branches:


### PR DESCRIPTION
sync/publish/unpublish will warns as before:

```
No git remotes configured. Please add one.
```

Other commands work with repositories without remote.

---

 legit/cli.py |  4 ++++
 legit/scm.py | 25 +++++++++++++++----------
 2 files changed, 19 insertions(+), 10 deletions(-)
