### PR TITLE
Add the packaging metadata to build the legit snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: legit
+version: master
+summary: Git for Humans
+description: |
+  Legit is a complementary command-line interface for Git, optimized for
+  workflow simplicity. It is heavily inspired by GitHub for Mac.
+
+grade: devel
+confinement: classic
+
+apps:
+  legit:
+    command: legit
+
+parts:
+  legit:
+    source: .
+    plugin: python
+    python-version: python2


### PR DESCRIPTION
This is a package for the secure installation of apps that will work in most Linux distributions.
Landing it upstream will enable to push builds to the Ubuntu store, and get updated versions to many users.