### PR TITLE
Add Python 3.5 & 3.6 language classifiers for 0.5.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ settings.update(
     install_requires=required,
     license='BSD',
     classifiers=[
-        # 'Development Status :: 5 - Production/Stable',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'License :: OSI Approved :: BSD License',
@@ -69,6 +69,8 @@ settings.update(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Also update Development Status to Production/Stable, since recent changes
for 0.5.x release fix many of the outstanding issues.