### PR TITLE
Rewrite with Click

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E265,E266,E501
+max-line-length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,17 @@
 *.pyc
 *.egg-info
+/.venv
+__pycache__/
+.cache
+pipenv.egg-info/
 
 builders/pyinstaller-1.5.1
 builders/artifacts/*
 dist/
 build/
+
+.sublime-text-git-autocommit
+/.vscode/
+.idea
+
+.DS_Store

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 History
 -------
 
+0.6.0
++++++
+
+* Refactor CLI using `click`
+
 0.5.0
 +++++
 

--- a/legit/__init__.py
+++ b/legit/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from .core import *
+from .core import *  # noqa

--- a/legit/bootstrap.py
+++ b/legit/bootstrap.py
@@ -25,8 +25,7 @@ except IOError:
 
 # Load existing configuration.
 config = configparser.ConfigParser()
-config.readfp(config_file)
-
+config.read_file(config_file)
 
 
 # Populate if needed.

--- a/legit/cli.py
+++ b/legit/cli.py
@@ -8,13 +8,12 @@ This module provides the CLI interface to legit.
 """
 
 import click
-from clint.textui import colored, columns
 
 from .core import __version__
 from .scm import *
 
 
-pass_repo = click.make_pass_decorator(Repo)
+pass_repo = click.make_pass_decorator(SCMRepo)
 
 
 @click.group()
@@ -27,42 +26,98 @@ def cli(ctx, verbose):
     # Create a repo object and remember it as as the context object.  From
     # this point onwards other commands can refer to it by using the
     # @pass_repo decorator.
-    ctx.obj = get_repo()
+    ctx.obj = SCMRepo()
     if ctx.obj:
-        ctx.obj.remote = get_remote(ctx.obj)
         ctx.obj.verbose = verbose
 
 
 @cli.command()
-@click.argument('to_branch')
+@click.argument('to_branch', required=False)
 @pass_repo
-def switch(repo, to_branch):
-    """Switches from one branch to another, safely stashing/restoring local changes.
+def switch(scm, to_branch):
+    """Switches from one branch to another, safely stashing and restoring local changes.
     """
     if to_branch is None:
         print('Please specify a branch to switch:')
-        display_available_branches(repo)
+        scm.display_available_branches()
         raise click.Abort
 
-    if repo.is_dirty():
-        status_log(stash_it, 'Saving local changes.', repo)
+    if scm.repo.is_dirty():
+        status_log(scm.stash_it, 'Saving local changes.')
 
-    status_log(checkout_branch, 'Switching to {0}.'.format(
-        colored.yellow(to_branch)), repo, to_branch)
+    status_log(scm.checkout_branch, 'Switching to {0}.'.format(
+        colored.yellow(to_branch)), to_branch)
 
-    if unstash_index(repo):
-        status_log(unstash_it, 'Restoring local changes.', repo)
+    if scm.unstash_index():
+        status_log(scm.repo.unstash_it, 'Restoring local changes.')
+
+
+@cli.command()
+@click.argument('branch', required=False)
+@pass_repo
+def sync(scm, to_branch):
+    """Stashes unstaged changes, Fetches remote data, Performs smart
+    pull+merge, Pushes local commits up, and Unstashes changes.
+
+    Defaults to current branch.
+    """
+
+    scm.repo_check(require_remote=True)
+
+    if to_branch:
+        # Optional branch specifier.
+        branch = scm.fuzzy_match_branch(to_branch)
+        if branch:
+            is_external = True
+            original_branch = scm.get_current_branch_name()
+        else:
+            print("{0} doesn't exist. Use a branch that does.".format(
+                colored.yellow(branch)))
+            sys.exit(1)
+    else:
+        # Sync current branch.
+        branch = scm.get_current_branch_name()
+        is_external = False
+
+    if branch in scm.get_branch_names(local=False):
+
+        if is_external:
+            switch(scm, branch)
+
+        if scm.repo.is_dirty():
+            status_log(scm.stash_it, 'Saving local changes.', sync=True)
+
+        status_log(scm.smart_pull, 'Pulling commits from the server.')
+        status_log(scm.push, 'Pushing commits to the server.', branch)
+
+        if scm.unstash_index(sync=True):
+            status_log(scm.unstash_it, 'Restoring local changes.', sync=True)
+
+        if is_external:
+            switch(scm, original_branch)
+
+    else:
+        print('{0} has not been published yet.'.format(
+            colored.yellow(branch)))
+        sys.exit(1)
+
+
+@cli.command()
+@pass_repo
+def branches(scm):
+    """Displays available branches."""
+    scm.display_available_branches()
 
 
 # -------
 # Helpers
 # -------
 
-def status_log(func, message, repo, *args, **kwargs):
+def status_log(func, message, *args, **kwargs):
     """Executes a callable with a header message."""
 
     click.echo(message)
-    log = func(repo, *args, **kwargs)
+    log = func(*args, **kwargs)
 
     if log:
         out = []
@@ -71,36 +126,3 @@ def status_log(func, message, repo, *args, **kwargs):
             if not line.startswith('#'):
                 out.append(line)
         click.secho('\n'.join(out), fg="black")
-
-
-def display_available_branches(repo):
-    """Displays available branches."""
-
-    if not repo.remotes:
-        remote_branches = False
-    else:
-        remote_branches = True
-    branches = get_branches(repo, local=True, remote_branches=remote_branches)
-
-    if not branches:
-        print(colored.red('No branches available'))
-        return
-
-    branch_col = len(max([b.name for b in branches], key=len)) + 1
-
-    for branch in branches:
-
-        try:
-            branch_is_selected = (branch.name == get_current_branch_name(repo))
-        except TypeError:
-            branch_is_selected = False
-
-        marker = '*' if branch_is_selected else ' '
-        color = colored.green if branch_is_selected else colored.yellow
-        pub = '(published)' if branch.is_published else '(unpublished)'
-
-        print(columns(
-            [colored.red(marker), 2],
-            [color(branch.name), branch_col],
-            [colored.black(pub), 14]
-        ))

--- a/legit/cli.py
+++ b/legit/cli.py
@@ -8,32 +8,40 @@ This module provides the CLI interface to legit.
 """
 
 import click
+from clint.textui import colored
+import difflib
 
 from .core import __version__
-from .scm import *
+from .scm import SCMRepo
+from .settings import settings
 
 
-pass_repo = click.make_pass_decorator(SCMRepo)
+pass_scm = click.make_pass_decorator(SCMRepo)
 
 
-@click.group()
-@click.option('--verbose', is_flag=True,
-              help='Enables verbose mode.')
+class LegitGroup(click.Group):
+    def list_commands(self, ctx):
+        commands = super(LegitGroup, self).list_commands(ctx)
+        return [cmd for cmd in sort_with_similarity(commands)]
+
+
+@click.group(cls=LegitGroup)
+# @click.option('--verbose', is_flag=True, help='Enables verbose mode.')
 @click.version_option(__version__)
 @click.pass_context
-def cli(ctx, verbose):
-    """Legit command dispatch"""
+def cli(ctx):
+    """legit : A Kenneth Reitz Project"""
     # Create a repo object and remember it as as the context object.  From
     # this point onwards other commands can refer to it by using the
     # @pass_repo decorator.
     ctx.obj = SCMRepo()
-    if ctx.obj:
-        ctx.obj.verbose = verbose
+    # if ctx.obj:
+    #     ctx.obj.verbose = verbose
 
 
-@cli.command()
+@cli.command(short_help='Switches to specified branch.')
 @click.argument('to_branch', required=False)
-@pass_repo
+@pass_scm
 def switch(scm, to_branch):
     """Switches from one branch to another, safely stashing and restoring local changes.
     """
@@ -52,10 +60,11 @@ def switch(scm, to_branch):
         status_log(scm.repo.unstash_it, 'Restoring local changes.')
 
 
-@cli.command()
+@cli.command(short_help='Synchronizes the given branch.')
 @click.argument('to_branch', required=False)
-@pass_repo
-def sync(scm, to_branch):
+@pass_scm
+@click.pass_context
+def sync(ctx, scm, to_branch):
     """Stashes unstaged changes, Fetches remote data, Performs smart
     pull+merge, Pushes local commits up, and Unstashes changes.
 
@@ -71,8 +80,9 @@ def sync(scm, to_branch):
             is_external = True
             original_branch = scm.get_current_branch_name()
         else:
-            click.echo("Branch {0} doesn't exist. Use a branch that does.".format(colored.yellow(branch)))
-            sys.exit(1)
+            click.echo("Branch {0} doesn't exist. Use a branch that does."
+                       .format(colored.yellow(branch)))
+            raise click.Abort
     else:
         # Sync current branch.
         branch = scm.get_current_branch_name()
@@ -81,7 +91,7 @@ def sync(scm, to_branch):
     if branch in scm.get_branch_names(local=False):
 
         if is_external:
-            switch(scm, branch)
+            ctx.invoke(switch, to_branch=branch)
 
         if scm.repo.is_dirty():
             status_log(scm.stash_it, 'Saving local changes.', sync=True)
@@ -93,16 +103,17 @@ def sync(scm, to_branch):
             status_log(scm.unstash_it, 'Restoring local changes.', sync=True)
 
         if is_external:
-            switch(scm, original_branch)
+            ctx.invoke(switch, to_branch=original_branch)
 
     else:
-        click.echo('Branch {0} is not published. Publish before syncing.'.format(colored.yellow(branch)))
-        sys.exit(1)
+        click.echo('Branch {0} is not published. Publish before syncing.'
+                   .format(colored.yellow(branch)))
+        raise click.Abort
 
 
-@cli.command()
+@cli.command(short_help='Publishes specified branch to the remote.')
 @click.argument('to_branch', required=False)
-@pass_repo
+@pass_scm
 def publish(scm, to_branch):
     """Pushes an unpublished branch to a remote repository."""
 
@@ -115,22 +126,25 @@ def publish(scm, to_branch):
         if to_branch is None:
             click.echo("Using current branch {0}".format(colored.yellow(branch)))
         else:
-            click.echo("Branch {0} not found, using current branch {1}".format(colored.red(to_branch), colored.yellow(branch)))
+            click.echo(
+                "Branch {0} not found, using current branch {1}"
+                .format(colored.red(to_branch), colored.yellow(branch)))
 
     branch_names = scm.get_branch_names(local=False)
 
     if branch in branch_names:
         click.echo("Branch {0} is already published. Use a branch that is not published.".format(
             colored.yellow(branch)))
-        sys.exit(1)
+        raise click.Abort
 
     status_log(scm.publish_branch, 'Publishing {0}.'.format(
         colored.yellow(branch)), branch)
 
-@cli.command()
-@click.argument('published_branch', required=False)
-@pass_repo
-def cmd_unpublish(scm, published_branch):
+
+@cli.command(short_help='Removes specified branch from the remote.')
+@click.argument('published_branch')
+@pass_scm
+def unpublish(scm, published_branch):
     """Removes a published branch from the remote repository."""
 
     scm.repo_check(require_remote=True)
@@ -146,23 +160,23 @@ def cmd_unpublish(scm, published_branch):
     if branch not in branch_names:
         click.echo("Branch {0} isn't published. Use a branch that is published.".format(
             colored.yellow(branch)))
-        sys.exit(1)
+        raise click.Abort
 
     status_log(scm.unpublish_branch, 'Unpublishing {0}.'.format(
         colored.yellow(branch)), branch)
 
 
 @cli.command()
-@pass_repo
+@pass_scm
 def branches(scm):
-    """Displays available branches."""
+    """Get a nice pretty list of branches."""
     scm.display_available_branches()
 
 
 @cli.command()
-@pass_repo
+@pass_scm
 def undo(scm):
-    """Makes last commit not exist."""
+    """Removes the last commit from history."""
     status_log(scm.undo, 'Last commit removed from history.')
 
 
@@ -183,3 +197,41 @@ def status_log(func, message, *args, **kwargs):
             if not line.startswith('#'):
                 out.append(line)
         click.secho('\n'.join(out), fg="black")
+
+
+def handle_abort(aborted, type=None):
+    click.echo('{0} {1}'.format(colored.red('Error:'), aborted.message))
+    click.echo(str(aborted.log))
+    if type == 'merge':
+        click.echo('Unfortunately, there was a merge conflict.'
+                   ' It has to be merged manually.')
+    elif type == 'unpublish':
+        click.echo(
+            '''It seems that the remote branch has been already deleted.
+            If `legit branches` still list it as published,
+            then probably the branch has been deleted at the remote by someone else.
+            You can run `git fetch --prune` to update remote information.
+            ''')
+    raise click.Abort
+
+
+settings.abort_handler = handle_abort
+
+
+def sort_with_similarity(iterable, key=None):
+    """Sort string list with similarity following original order."""
+    if key is None:
+        key = lambda x: x
+    ordered = []
+    left_iterable = dict(zip([key(elm) for elm in iterable], iterable))
+    for k in list(left_iterable.keys()):
+        if k not in left_iterable:
+            continue
+        ordered.append(left_iterable[k])
+        del left_iterable[k]
+        # find close named iterable
+        close_iterable = difflib.get_close_matches(k, left_iterable.keys())
+        for close in close_iterable:
+            ordered.append(left_iterable[close])
+            del left_iterable[close]
+    return ordered

--- a/legit/cli.py
+++ b/legit/cli.py
@@ -57,8 +57,7 @@ def cli(ctx):
     # this point onwards other commands can refer to it by using the
     # @pass_scm decorator.
     ctx.obj = SCMRepo()
-    # if ctx.obj:
-    #     ctx.obj.verbose = verbose
+    # ctx.obj.verbose = verbose
 
 
 @cli.command(short_help='Switches to specified branch.')
@@ -79,7 +78,7 @@ def switch(scm, to_branch):
         colored.yellow(to_branch)), to_branch)
 
     if scm.unstash_index():
-        status_log(scm.repo.unstash_it, 'Restoring local changes.')
+        status_log(scm.unstash_it, 'Restoring local changes.')
 
 
 @cli.command(short_help='Synchronizes the given branch.')

--- a/legit/cli.py
+++ b/legit/cli.py
@@ -53,7 +53,7 @@ def switch(scm, to_branch):
 
 
 @cli.command()
-@click.argument('branch', required=False)
+@click.argument('to_branch', required=False)
 @pass_repo
 def sync(scm, to_branch):
     """Stashes unstaged changes, Fetches remote data, Performs smart

--- a/legit/cli.py
+++ b/legit/cli.py
@@ -16,7 +16,7 @@ import difflib
 
 from .core import __version__
 from .helpers import is_lin, is_osx, is_win
-from .scm import SCMRepo
+from .scm import SCMRepo, black
 from .settings import settings
 
 
@@ -314,10 +314,3 @@ def sort_with_similarity(iterable, key=None):
             ordered.append(left_iterable[close])
             del left_iterable[close]
     return ordered
-
-
-def black(s):
-    if settings.allow_black_foreground:
-        return colored.black(s)
-    else:
-        return s.encode('utf-8')

--- a/legit/core.py
+++ b/legit/core.py
@@ -10,7 +10,7 @@ This module provides the basic functionality of legit.
 from . import bootstrap
 del bootstrap
 
-__version__ = '0.5.0'
+__version__ = '0.5.2'
 __author__ = 'Kenneth Reitz'
 __license__ = 'BSD'
 

--- a/legit/core.py
+++ b/legit/core.py
@@ -13,4 +13,3 @@ del bootstrap
 __version__ = '0.5.2'
 __author__ = 'Kenneth Reitz'
 __license__ = 'BSD'
-

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -13,6 +13,7 @@ from collections import namedtuple
 from operator import attrgetter
 
 import clint
+from clint.textui import colored, columns
 from git import Repo
 from git.exc import GitCommandError, InvalidGitRepositoryError
 
@@ -41,213 +42,311 @@ def abort(message, log=None, type=None):
     settings.abort_handler(a, type=type)
 
 
-def repo_check(repo, require_remote=False):
-    if repo is None:
-        print('Not a git repository.')
-        sys.exit(128)
+class SCMRepo(object):
+    repo = None
+    remote = None
+    verbose = False
 
-    # TODO: no remote fail
-    if not repo.remotes and require_remote:
-        print('No git remotes configured. Please add one.')
-        sys.exit(128)
-
-    # TODO: You're in a merge state.
-
-
-def stash_it(repo, sync=False):
-    repo_check(repo)
-    msg = 'syncing branch' if sync else 'switching branches'
-
-    return repo.git.execute([git,
-        'stash', 'save', '--include-untracked',
-        LEGIT_TEMPLATE.format(msg)])
-
-
-def unstash_index(repo, sync=False, branch=None):
-    """Returns an unstash index if one is available."""
-
-    repo_check(repo)
-
-    stash_list = repo.git.execute([git, 'stash', 'list'])
-
-    if branch is None:
-        branch = get_current_branch_name(repo)
-
-    for stash in stash_list.splitlines():
-
-        verb = 'syncing' if sync else 'switching'
-
-        if (
-            (('Legit' in stash) and
-                ('On {0}:'.format(branch) in stash) and
-                (verb in stash))
-            or (('GitHub' in stash) and
-                ('On {0}:'.format(branch) in stash) and
-                (verb in stash))
-        ):
-            return stash[7]
-
-
-def unstash_it(repo, sync=False, branch=None):
-    """Unstashes changes from current branch for branch sync."""
-
-    repo_check(repo)
-
-    stash_index = unstash_index(repo, sync=sync, branch=branch)
-
-    if stash_index is not None:
-        return repo.git.execute([git,
-            'stash', 'pop', 'stash@{{{0}}}'.format(stash_index)])
-
-
-def smart_pull(repo):
-    'git log --merges origin/master..master'
-
-    repo_check(require_remote=True)
-
-    branch = get_current_branch_name()
-
-    repo.git.execute([git, 'fetch', repo.remote.name])
-
-    return smart_merge('{0}/{1}'.format(repo.remote.name, branch), smart_merge_enabled())
-
-
-def smart_merge_enabled(repo):
-    reader = repo.config_reader()
-    if reader.has_option('legit', 'smartMerge'):
-        return reader.getboolean('legit', 'smartMerge')
-    else:
-        return True
-
-
-def smart_merge(repo, branch, allow_rebase=True):
-
-    repo_check(repo)
-
-    from_branch = get_current_branch_name()
-
-    merges = repo.git.execute([git,
-        'log', '--merges', '{0}..{1}'.format(branch, from_branch)])
-
-    if allow_rebase:
-        verb = 'merge' if merges.count('commit') else 'rebase'
-    else:
-        if git_pull_rebase():
-            verb = 'rebase'
-        else:
-            verb = 'merge'
-
-    if git_pull_ff_only():
-        return repo.git.execute([git, verb, '--ff-only', branch])
-    else:
+    def __init__(self):
         try:
-            return repo.git.execute([git, verb, branch])
-        except GitCommandError as why:
-            log = repo.git.execute([git, verb, '--abort'])
-            abort('Merge failed. Reverting.',
-                  log='{0}\n{1}'.format(why, log), type='merge')
+            self.repo = Repo(search_parent_directories=True)
+            self.remote = self.get_remote()
+        except InvalidGitRepositoryError:
+            self.repo = None
 
+    def repo_check(self, require_remote=False):
+        if self.repo is None:
+            print('Not a git repository.')
+            sys.exit(128)
 
-def git_pull_rebase(repo):
-    reader = repo.config_reader()
-    if reader.has_option('pull', 'rebase'):
-        return reader.getboolean('pull', 'rebase')
-    else:
-        return False
+        # TODO: no remote fail
+        if not self.repo.remotes and require_remote:
+            print('No git remotes configured. Please add one.')
+            sys.exit(128)
 
+        # TODO: You're in a merge state.
 
-def git_pull_ff_only(repo):
-    reader = repo.config_reader()
-    if reader.has_option('pull', 'ff'):
-        if reader.getboolean('pull', 'ff') == "only":
+    def stash_it(self, sync=False):
+        self.repo_check()
+        msg = 'syncing branch' if sync else 'switching branches'
+
+        return self.repo.git.execute(
+            [git, 'stash', 'save', '--include-untracked', LEGIT_TEMPLATE.format(msg)])
+
+    def unstash_index(self, sync=False, branch=None):
+        """Returns an unstash index if one is available."""
+
+        self.repo_check()
+
+        stash_list = self.repo.git.execute([git, 'stash', 'list'])
+
+        if branch is None:
+            branch = self.get_current_branch_name()
+
+        for stash in stash_list.splitlines():
+
+            verb = 'syncing' if sync else 'switching'
+
+            if (
+                (('Legit' in stash) and
+                    ('On {0}:'.format(branch) in stash) and
+                    (verb in stash))
+                or (('GitHub' in stash) and
+                    ('On {0}:'.format(branch) in stash) and
+                    (verb in stash))
+            ):
+                return stash[7]
+
+    def unstash_it(self, sync=False, branch=None):
+        """Unstashes changes from current branch for branch sync."""
+
+        self.repo_check()
+
+        stash_index = self.unstash_index(sync=sync, branch=branch)
+
+        if stash_index is not None:
+            return self.repo.git.execute(
+                [git, 'stash', 'pop', 'stash@{{{0}}}'.format(stash_index)])
+
+    def smart_pull(self):
+        """
+        'git log --merges origin/master..master'
+        """
+
+        self.repo_check(require_remote=True)
+
+        branch = self.get_current_branch_name()
+
+        self.repo.git.execute([git, 'fetch', self.remote.name])
+
+        return self.smart_merge('{0}/{1}'.format(self.remote.name, branch),
+                                self.smart_merge_enabled())
+
+    def smart_merge_enabled(self):
+        reader = self.repo.config_reader()
+        if reader.has_option('legit', 'smartMerge'):
+            return reader.getboolean('legit', 'smartMerge')
+        else:
             return True
+
+    def smart_merge(self, branch, allow_rebase=True):
+
+        self.repo_check()
+
+        from_branch = self.get_current_branch_name()
+
+        merges = self.repo.git.execute(
+            [git, 'log', '--merges', '{0}..{1}'.format(branch, from_branch)])
+
+        if allow_rebase:
+            verb = 'merge' if merges.count('commit') else 'rebase'
+        else:
+            if self.git_pull_rebase():
+                verb = 'rebase'
+            else:
+                verb = 'merge'
+
+        if self.git_pull_ff_only():
+            return self.repo.git.execute([git, verb, '--ff-only', branch])
+        else:
+            try:
+                return self.repo.git.execute([git, verb, branch])
+            except GitCommandError as why:
+                log = self.repo.git.execute([git, verb, '--abort'])
+                abort('Merge failed. Reverting.',
+                      log='{0}\n{1}'.format(why, log), type='merge')
+
+    def git_pull_rebase(self):
+        reader = self.repo.config_reader()
+        if reader.has_option('pull', 'rebase'):
+            return reader.getboolean('pull', 'rebase')
         else:
             return False
-    else:
-        return False
 
-
-def push(repo, branch=None):
-
-    repo_check(repo, require_remote=True)
-
-    if branch is None:
-        return repo.git.execute([git, 'push'])
-    else:
-        return repo.git.execute([git, 'push', repo.remote.name, branch])
-
-
-def checkout_branch(repo, branch):
-    """Checks out given branch."""
-
-    repo_check(repo)
-
-    _, stdout, stderr = repo.git.execute([git, 'checkout', branch],
-                                         with_extended_output=True)
-    return '\n'.join([stderr, stdout])
-
-
-def unpublish_branch(repo, branch):
-    """Unpublishes given branch."""
-
-    repo_check(repo, require_remote=True)
-
-    try:
-        return repo.git.execute([git,
-            'push', repo.remote.name, ':{0}'.format(branch)])
-    except GitCommandError:
-        _, _, log = repo.git.execute([git, 'fetch', repo.remote.name, '--prune'],
-                                     with_extended_output=True)
-        abort('Unpublish failed. Fetching.', log=log, type='unpublish')
-
-
-def publish_branch(repo, branch):
-    """Publishes given branch."""
-
-    repo_check(repo, require_remote=True)
-
-    return repo.git.execute([git,
-        'push', '-u', repo.remote.name, branch])
-
-
-def get_repo():
-    """Returns the current Repo, based on path."""
-
-    try:
-        return Repo(search_parent_directories=True)
-    except InvalidGitRepositoryError:
-        pass
-
-
-def get_remote(repo):
-
-    repo_check(repo)
-
-    reader = repo.config_reader()
-
-    # If there is no remote option in legit section, return default
-    if reader.has_option('legit', 'remote'):
-        remote_name = reader.get('legit', 'remote')
-        if remote_name not in [r.name for r in repo.remotes]:
-            if fallback_enabled(reader):
-                return get_default_remote()
+    def git_pull_ff_only(self):
+        reader = self.repo.config_reader()
+        if reader.has_option('pull', 'ff'):
+            if reader.getboolean('pull', 'ff') == "only":
+                return True
             else:
-                print('Remote "{0}" does not exist!'.format(remote_name))
-                will_aborted = clint.textui.prompt.yn(
-                    '\nPress `y` to abort now,\n' +
-                    '`n` to use default remote and turn fallback on for this repo:')
-                if will_aborted:
-                    print('\nAborted. Please update your git configuration.')
-                    sys.exit(64)  # EX_USAGE
-                else:
-                    writer = repo.config_writer()
-                    writer.set_value('legit', 'remoteFallback', 'true')
-                    print('\n`legit.RemoteFallback` changed to true for current repo.')
-                    return get_default_remote(repo)
+                return False
         else:
-            return repo.remote(remote_name)
-    else:
-        return get_default_remote(repo)
+            return False
+
+    def push(self, branch=None):
+
+        self.repo_check(require_remote=True)
+
+        if branch is None:
+            return self.repo.git.execute([git, 'push'])
+        else:
+            return self.repo.git.execute([git, 'push', self.remote.name, branch])
+
+    def checkout_branch(self, branch):
+        """Checks out given branch."""
+
+        self.repo_check()
+
+        _, stdout, stderr = self.repo.git.execute(
+            [git, 'checkout', branch],
+            with_extended_output=True)
+        return '\n'.join([stderr, stdout])
+
+    def unpublish_branch(self, branch):
+        """Unpublishes given branch."""
+
+        self.repo_check(require_remote=True)
+
+        try:
+            return self.repo.git.execute(
+                [git, 'push', self.remote.name, ':{0}'.format(branch)])
+        except GitCommandError:
+            _, _, log = self.repo.git.execute(
+                [git, 'fetch', self.remote.name, '--prune'],
+                with_extended_output=True)
+            abort('Unpublish failed. Fetching.', log=log, type='unpublish')
+
+    def publish_branch(self, branch):
+        """Publishes given branch."""
+
+        self.repo_check(require_remote=True)
+
+        return self.repo.git.execute(
+            [git, 'push', '-u', self.remote.name, branch])
+
+    def get_remote(self):
+
+        self.repo_check()
+
+        reader = self.repo.config_reader()
+
+        # If there is no remote option in legit section, return default
+        if reader.has_option('legit', 'remote'):
+            remote_name = reader.get('legit', 'remote')
+            if remote_name not in [r.name for r in self.repo.remotes]:
+                if fallback_enabled(reader):
+                    return self.get_default_remote()
+                else:
+                    print('Remote "{0}" does not exist!'.format(remote_name))
+                    will_aborted = clint.textui.prompt.yn(
+                        '\nPress `y` to abort now,\n' +
+                        '`n` to use default remote and turn fallback on for this repo:')
+                    if will_aborted:
+                        print('\nAborted. Please update your git configuration.')
+                        sys.exit(64)  # EX_USAGE
+                    else:
+                        writer = self.repo.config_writer()
+                        writer.set_value('legit', 'remoteFallback', 'true')
+                        print('\n`legit.RemoteFallback` changed to true for current repo.')
+                        return self.get_default_remote()
+            else:
+                return self.remote(remote_name)
+        else:
+            return self.get_default_remote()
+
+    def get_default_remote(self):
+        if len(self.repo.remotes) == 0:
+            return None
+        else:
+            return self.repo.remotes[0]
+
+    def get_current_branch_name(self):
+        """Returns current branch name"""
+
+        self.repo_check()
+
+        return self.repo.head.ref.name
+
+    def fuzzy_match_branch(self, branch):
+        if not branch:
+            return False
+
+        all_branches = self.get_branch_names()
+        if branch in all_branches:
+            return branch
+
+        def branch_fuzzy_match(b):
+            return b.startswith(branch)
+
+        possible_branches = list(filter(branch_fuzzy_match, all_branches))
+
+        if len(possible_branches) == 1:
+            return possible_branches[0]
+
+        return branch
+
+    def get_branches(self, local=True, remote_branches=True):
+        """Returns a list of local and remote branches."""
+
+        self.repo_check()
+
+        if not self.repo.remotes:
+            remote_branches = False
+
+        branches = []
+
+        if remote_branches:
+
+            # Remote refs.
+            try:
+                for b in self.remote.refs:
+                    name = '/'.join(b.name.split('/')[1:])
+
+                    if name not in settings.forbidden_branches:
+                        branches.append(Branch(name, is_published=True))
+            except (IndexError, AssertionError):
+                pass
+
+        if local:
+
+            # Local refs.
+            for b in [h.name for h in self.repo.heads]:
+
+                if (not remote_branches) or (b not in [br.name for br in branches]):
+                    if b not in settings.forbidden_branches:
+                        branches.append(Branch(b, is_published=False))
+
+        return sorted(branches, key=attrgetter('name'))
+
+    def get_branch_names(self, local=True, remote_branches=True):
+
+        self.repo_check()
+
+        branches = self.get_branches(local=local, remote_branches=remote_branches)
+
+        return [b.name for b in branches]
+
+    def display_available_branches(self):
+        """Displays available branches."""
+
+        if not self.repo.remotes:
+            remote_branches = False
+        else:
+            remote_branches = True
+        branches = self.get_branches(local=True, remote_branches=remote_branches)
+
+        if not branches:
+            print(colored.red('No branches available'))
+            return
+
+        branch_col = len(max([b.name for b in branches], key=len)) + 1
+
+        for branch in branches:
+
+            try:
+                branch_is_selected = (branch.name == self.get_current_branch_name())
+            except TypeError:
+                branch_is_selected = False
+
+            marker = '*' if branch_is_selected else ' '
+            color = colored.green if branch_is_selected else colored.yellow
+            pub = '(published)' if branch.is_published else '(unpublished)'
+
+            print(columns(
+                [colored.red(marker), 2],
+                [color(branch.name), branch_col],
+                [colored.black(pub), 14]
+            ))
 
 
 # Instead of getboolean('legit', 'remoteFallback', fallback=False)
@@ -257,62 +356,3 @@ def fallback_enabled(reader):
         return reader.getboolean('legit', 'remoteFallback')
     else:
         return False
-
-
-def get_default_remote(repo):
-    if len(repo.remotes) == 0:
-        return None
-    else:
-        return repo.remotes[0]
-
-
-def get_current_branch_name(repo):
-    """Returns current branch name"""
-
-    repo_check(repo)
-
-    return repo.head.ref.name
-
-
-def get_branches(repo, local=True, remote_branches=True):
-    """Returns a list of local and remote branches."""
-
-    repo_check(repo)
-
-    if not repo.remotes:
-        remote_branches = False
-
-    branches = []
-
-    if remote_branches:
-
-        # Remote refs.
-        try:
-            for b in repo.remote.refs:
-                name = '/'.join(b.name.split('/')[1:])
-
-                if name not in settings.forbidden_branches:
-                    branches.append(Branch(name, is_published=True))
-        except (IndexError, AssertionError):
-            pass
-
-    if local:
-
-        # Local refs.
-        for b in [h.name for h in repo.heads]:
-
-            if (not remote_branches) or (b not in [br.name for br in branches]):
-                if b not in settings.forbidden_branches:
-                    branches.append(Branch(b, is_published=False))
-
-
-    return sorted(branches, key=attrgetter('name'))
-
-
-def get_branch_names(repo, local=True, remote_branches=True):
-
-    repo_check(repo)
-
-    branches = get_branches(local=local, remote_branches=remote_branches)
-
-    return [b.name for b in branches]

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -18,6 +18,7 @@ from clint.textui import colored, columns
 from git import Repo
 from git.exc import GitCommandError, InvalidGitRepositoryError
 
+from .cli import black
 from .settings import settings
 
 LEGIT_TEMPLATE = 'Legit: stashing before {0}.'
@@ -90,11 +91,13 @@ class SCMRepo(object):
 
             if (
                 (('Legit' in stash) and
-                    ('On {0}:'.format(branch) in stash) and
-                    (verb in stash))
-                or (('GitHub' in stash) and
-                    ('On {0}:'.format(branch) in stash) and
-                    (verb in stash))
+                 ('On {0}:'.format(branch) in stash) and
+                 (verb in stash)
+                 ) or
+                (('GitHub' in stash) and
+                 ('On {0}:'.format(branch) in stash) and
+                 (verb in stash)
+                 )
             ):
                 return stash[7]
 
@@ -142,12 +145,12 @@ class SCMRepo(object):
         if allow_rebase:
             verb = 'merge' if merges.count('commit') else 'rebase'
         else:
-            if self.git_pull_rebase():
+            if self.pull_rebase():
                 verb = 'rebase'
             else:
                 verb = 'merge'
 
-        if self.git_pull_ff_only():
+        if self.pull_ff_only():
             return self.repo.git.execute([git, verb, '--ff-only', branch])
         else:
             try:
@@ -157,14 +160,14 @@ class SCMRepo(object):
                 abort('Merge failed. Reverting.',
                       log='{0}\n{1}'.format(why, log), type='merge')
 
-    def git_pull_rebase(self):
+    def pull_rebase(self):
         reader = self.repo.config_reader()
         if reader.has_option('pull', 'rebase'):
             return reader.getboolean('pull', 'rebase')
         else:
             return False
 
-    def git_pull_ff_only(self):
+    def pull_ff_only(self):
         reader = self.repo.config_reader()
         if reader.has_option('pull', 'ff'):
             if reader.getboolean('pull', 'ff') == "only":
@@ -350,7 +353,7 @@ class SCMRepo(object):
             click.echo(columns(
                 [colored.red(marker), 2],
                 [color(branch.name), branch_col],
-                [colored.black(pub), 14]
+                [black(pub), 14]
             ))
 
 

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -18,7 +18,6 @@ from clint.textui import colored, columns
 from git import Repo
 from git.exc import GitCommandError, InvalidGitRepositoryError
 
-from .cli import black
 from .settings import settings
 
 LEGIT_TEMPLATE = 'Legit: stashing before {0}.'
@@ -364,3 +363,10 @@ def fallback_enabled(reader):
         return reader.getboolean('legit', 'remoteFallback')
     else:
         return False
+
+
+def black(s):
+    if settings.allow_black_foreground:
+        return colored.black(s)
+    else:
+        return s.encode('utf-8')

--- a/legit/settings.py
+++ b/legit/settings.py
@@ -20,7 +20,6 @@ class Settings(object):
 
         self.__dict__ = self._singleton
 
-
     def __call__(self, *args, **kwargs):
         # new instance of class to call
         r = self.__class__()
@@ -34,17 +33,14 @@ class Settings(object):
 
         return r
 
-
     def __enter__(self):
         pass
-
 
     def __exit__(self, *args):
 
         # restore cached copy
         self.__dict__.update(self.__cache.copy())
         del self.__cache
-
 
     def __getattribute__(self, key):
         if key in object.__getattribute__(self, '__attrs__'):
@@ -53,6 +49,7 @@ class Settings(object):
             except AttributeError:
                 return None
         return object.__getattribute__(self, key)
+
 
 settings = Settings()
 
@@ -74,4 +71,4 @@ settings.config_defaults = (
 
 
 settings.update_url = 'https://api.github.com/repos/kennethreitz/legit/tags'
-settings.forbidden_branches = ['HEAD',]
+settings.forbidden_branches = ['HEAD']

--- a/reqs.txt
+++ b/reqs.txt
@@ -1,5 +1,6 @@
 appdirs==1.4.0
 args==0.1.0
+click==6.7
 clint==0.5.1
 gitdb2==2.0.0
 GitPython==2.1.8

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup  # Always prefer setuptools over distutils
 
 APP_NAME = 'legit'
 APP_SCRIPT = './legit_r'
-VERSION = '0.5.0'
+VERSION = '0.5.2'
 
 
 # Grab requirements.
@@ -72,7 +72,7 @@ settings.update(
     ],
     entry_points={
         'console_scripts': [
-            'legit = legit.cli:main',
+            'legit = legit.cli:cli',
         ],
     }
 )


### PR DESCRIPTION
Implement the command line argument handling and configuration with `click`.

Why?

- ease testing complexity ([click.testing.CliRunner](http://click.pocoo.org/5/testing/#testing-click-applications))
- remove cruft and standardize on `click` arg-parsing library, familiar to many devs
- simplify adding sub-command options (see [click docs](http://click.pocoo.org/5/why/))
- currently v0.5.0 `$ legit sync --help` does not provide any help, thinks “--help” is the branch name
- new `SCMRepo` class simplifies sub-command argument references and shares common methods
- improves display compatibility with various OSes by virtue of using click.echo() functions

Possible issues:
- `git_transparency` is not possible without considerable work, tough to implement with `click`
- custom help output (i.e. v0.5.0 two-line output for each sub-command) will require additional work.


See subsequent PR https://github.com/kennethreitz/legit/pull/233 for further development using the same codebase.